### PR TITLE
Fix plistlib error for Alfred 5

### DIFF
--- a/src/alfred.py
+++ b/src/alfred.py
@@ -19,7 +19,8 @@ UNESCAPE_CHARACTERS = u""" ;()"""
 
 _MAX_RESULTS_DEFAULT = 9
 
-preferences = plistlib.readPlist('info.plist')
+with open('info.plist', 'rb') as fp :
+    preferences = plistlib.loads(fp.read())
 bundleid = preferences['bundleid']
 
 


### PR DESCRIPTION
This fixes an error which prevented the authenticator to work on Alfred 5.